### PR TITLE
refactor: OAuth error handling

### DIFF
--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -155,6 +155,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
       <artifactId>hibernate-jpa-2.1-api</artifactId>
     </dependency>

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/HttpClientErrorExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/HttpClientErrorExceptionMapper.java
@@ -15,7 +15,7 @@
  */
 package io.syndesis.rest.v1.handler.exception;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -34,7 +34,7 @@ public class HttpClientErrorExceptionMapper implements ExceptionMapper<HttpClien
         RestError error = new RestError(
                 exception.getMessage(),
                 exception.getMessage(),
-                ErrorMap.from(new String(exception.getResponseBodyAsByteArray(), Charset.forName("UTF-8"))).getError(),
+                ErrorMap.from(new String(exception.getResponseBodyAsByteArray(), StandardCharsets.UTF_8)),
                 exception.getStatusCode().value());
         return Response.status(exception.getStatusCode().value()).type(MediaType.APPLICATION_JSON_TYPE).entity(error).build();
     }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/HttpServerErrorExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/HttpServerErrorExceptionMapper.java
@@ -15,7 +15,7 @@
  */
 package io.syndesis.rest.v1.handler.exception;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -34,7 +34,7 @@ public class HttpServerErrorExceptionMapper implements ExceptionMapper<HttpServe
         RestError error = new RestError(
                 exception.getMessage(),
                 exception.getMessage(),
-                ErrorMap.from(new String(exception.getResponseBodyAsByteArray(), Charset.forName("UTF-8"))).getError(),
+                ErrorMap.from(new String(exception.getResponseBodyAsByteArray(), StandardCharsets.UTF_8)),
                 exception.getStatusCode().value());
         return Response.status(exception.getStatusCode().value()).type(MediaType.APPLICATION_JSON_TYPE).entity(error).build();
     }

--- a/rest/src/test/java/io/syndesis/rest/v1/handler/exception/ErrorMapTest.java
+++ b/rest/src/test/java/io/syndesis/rest/v1/handler/exception/ErrorMapTest.java
@@ -15,42 +15,60 @@
  */
 package io.syndesis.rest.v1.handler.exception;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ErrorMapTest {
 
     @Test
-    public void testUnmarshalXML() throws IOException {
+    public void testUnmarshalXML() {
         String rawMsg = read("/HttpClientErrorException.xml");
-        ErrorMap errorMap = ErrorMap.from(rawMsg);
-        assertThat(errorMap.getError()).isEqualTo("Desktop applications only support the oauth_callback value 'oob'");
+        assertThat(ErrorMap.from(rawMsg)).isEqualTo("Desktop applications only support the oauth_callback value 'oob'");
     }
 
     @Test
-    public void testUnmarshalJSON() throws IOException {
+    public void testUnmarshalJSON() {
         String rawMsg = read("/HttpClientErrorException.json");
-        ErrorMap errorMap = ErrorMap.from(rawMsg);
-        assertThat(errorMap.getError()).isEqualTo("Could not authenticate you.");
+        assertThat(ErrorMap.from(rawMsg)).isEqualTo("Could not authenticate you.");
     }
 
     @Test
-    public void testUnmarshalImpossible() throws IOException {
+    public void testUnmarshalJSONVaryingFormats() {
+        assertThat(ErrorMap.from("{\"error\": \"some error\"}")).isEqualTo("some error");
+        assertThat(ErrorMap.from("{\"message\": \"some message\"}")).isEqualTo("some message");
+    }
+
+    @Test
+    public void testUnmarshalImpossible() {
         String rawMsg = "This is just some other error format";
-        ErrorMap errorMap = ErrorMap.from(rawMsg);
-        assertThat(errorMap.getError()).isEqualTo(rawMsg);
+        assertThat(ErrorMap.from(rawMsg)).isEqualTo(rawMsg);
+    }
+
+    @Test
+    public void shouldTryToLookupInJson() {
+        final JsonNodeFactory factory = JsonNodeFactory.instance;
+        final ObjectNode obj = factory.objectNode();
+        obj.set("a", factory.arrayNode().add("b").add("c"));
+        obj.set("x", factory.objectNode().set("y", factory.objectNode().put("z", "!")));
+
+        assertThat(ErrorMap.tryLookingUp(obj, "a")).contains("b");
+        assertThat(ErrorMap.tryLookingUp(obj, "a", "b")).isEmpty();
+        assertThat(ErrorMap.tryLookingUp(obj, "x", "y")).contains("{\"z\":\"!\"}");
+        assertThat(ErrorMap.tryLookingUp(obj, "x", "y", "z")).contains("!");
     }
 
     private static String read(final String path) {
         try {
-            return String.join("",
-                Files.readAllLines(Paths.get(ErrorMapTest.class.getResource(path).toURI())));
+            return String.join("", Files.readAllLines(Paths.get(ErrorMapTest.class.getResource(path).toURI())));
         } catch (IOException | URISyntaxException e) {
             throw new IllegalArgumentException("Unable to read from path: " + path, e);
         }


### PR DESCRIPTION
I wanted to share code paths for XML and JSON error responses to ease
adding other error message extraction paths. This changes to use Jackson
for both JSON and XML responses.
Could not find any usage of ErrorMap.request so I refactored the
ErrorMap to be a utility class that just extracts the error message from
the response.
It could happen that some of the responses start with whitespace
characters so I switched to using regexp to guess the format.
I thought that it would make sense if the error message is not parsed we
could benefit from having the response included verbatim, I'm thinking
situations like screenshots where even if the error is quite ugly to
present it would help us troubleshoot.